### PR TITLE
chore: add project board configuration

### DIFF
--- a/.claude/pm-config.md
+++ b/.claude/pm-config.md
@@ -4,6 +4,17 @@
 - Owner: nickmeinhold
 - Repo: watermarking
 
+## Project Board
+```
+PROJECT_ID="PVT_kwHOABApzM4BMd7I"
+STATUS_FIELD_ID="PVTSSF_lAHOABApzM4BMd7Izg7vbz4"
+STATUS_TODO="f75ad846"
+STATUS_IN_PROGRESS="47fc9ee4"
+STATUS_DONE="98236657"
+PROJECT_NUMBER="5"
+```
+URL: https://github.com/users/nickmeinhold/projects/5
+
 ## Labels
 Standard labels:
 - `bug` - Something isn't working


### PR DESCRIPTION
Adds project board IDs to pm-config.md for /pm command integration.

Project: https://github.com/users/nickmeinhold/projects/5