### PR TITLE
test(ios): add unit tests for iOS native code

### DIFF
--- a/.claude/research-config.md
+++ b/.claude/research-config.md
@@ -1,0 +1,35 @@
+# Research Configuration
+
+## Project Context
+Digital watermarking system for embedding and detecting invisible messages in images that survive print-and-scan.
+
+## Tech Stack
+- **Flutter/Dart**: watermarking_core (shared), watermarking_mobile (iOS), watermarking_webapp (web)
+- **Node.js**: watermarking-docker (backend queue processing)
+- **C++/OpenCV**: watermarking-functions (DFT-based watermark algorithms)
+- **Firebase**: Firestore, Storage, Auth (project: watermarking-4a428)
+
+## Research Priorities
+- Image processing and computer vision techniques
+- DFT/FFT watermarking algorithms and robustness
+- iOS Vision Framework and ARKit for rectangle detection
+- Flutter cross-platform patterns
+- Firebase/GCP best practices
+
+## Preferred Sources
+- pub.dev for Flutter/Dart packages
+- OpenCV documentation for image processing
+- Apple Developer docs for iOS Vision/ARKit
+- Firebase documentation
+- Academic papers for watermarking algorithms (IEEE, ACM)
+
+## Project Structure Reference
+See CLAUDE.md in project root for full architecture diagram and file locations.
+
+## Output Format
+Write findings to `RESEARCH.md` with:
+- Clear title and date
+- Executive summary
+- Detailed findings with code examples where applicable
+- Recommendations specific to this project's architecture
+- References and links to sources

--- a/.claude/slides-config.md
+++ b/.claude/slides-config.md
@@ -1,0 +1,53 @@
+# Slides Configuration
+
+## Project Context
+Watermarking - Digital watermarking system for embedding and detecting invisible messages in images.
+
+## Brand Colors
+```json
+{
+  "primary": { "red": 0.15, "green": 0.30, "blue": 0.55 },
+  "accent": { "red": 0.25, "green": 0.65, "blue": 0.85 },
+  "success": { "red": 0.20, "green": 0.65, "blue": 0.35 },
+  "warning": { "red": 0.95, "green": 0.65, "blue": 0.15 },
+  "text": { "red": 0.20, "green": 0.20, "blue": 0.25 },
+  "white": { "red": 1, "green": 1, "blue": 1 }
+}
+```
+
+## Slide Style Preferences
+- Clean, technical aesthetic
+- Use diagrams for architecture explanations
+- Include code snippets where relevant
+- Dark primary background for title slides
+- White background for content slides
+
+## Common Presentation Types
+
+### Technical Overview
+1. Title + project description
+2. Architecture diagram (mobile, web, backend, C++ engine)
+3. Detection flow explanation
+4. Marking flow explanation
+5. Demo / Next steps
+
+### Status Update
+1. Title + date
+2. Completed work
+3. Current blockers
+4. Upcoming tasks
+5. Demo or metrics
+
+### Feature Deep-Dive
+1. Feature title
+2. Problem / motivation
+3. Technical approach
+4. Implementation details
+5. Results / metrics
+
+## Key Talking Points
+- Print-and-scan resilient watermarking
+- DFT-based embedding and extraction
+- iOS Vision Framework for rectangle detection
+- Real-time statistics and visualization (11 charts)
+- Firebase-based queue processing

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,7 @@ jobs:
           # Check which areas changed
           echo "docker=$([[ "$CHANGED" == *"watermarking-docker/"* ]] && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "dart=$([[ "$CHANGED" == *"watermarking_core/"* || "$CHANGED" == *"watermarking_mobile/"* || "$CHANGED" == *"watermarking_webapp/"* ]] && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "ios=$([[ "$CHANGED" == *"watermarking_mobile/ios/"* ]] && echo true || echo false)" >> $GITHUB_OUTPUT
 
       - name: Setup Node.js
         if: steps.changed.outputs.docker == 'true'
@@ -79,3 +80,49 @@ jobs:
         if: steps.changed.outputs.dart == 'true'
         run: flutter test
         working-directory: watermarking_core
+
+    outputs:
+      ios: ${{ steps.changed.outputs.ios }}
+
+  ios-tests:
+    name: iOS Unit Tests
+    runs-on: macos-latest
+    needs: analyze-and-test
+    if: needs.analyze-and-test.outputs.ios == 'true'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Flutter
+        uses: subosito/flutter-action@v2
+        with:
+          channel: stable
+          cache: true
+
+      - name: Install Flutter dependencies
+        run: flutter pub get
+        working-directory: watermarking_mobile
+
+      - name: Install CocoaPods
+        run: |
+          cd watermarking_mobile/ios
+          pod install
+
+      - name: Run iOS unit tests
+        run: |
+          cd watermarking_mobile/ios
+          xcodebuild test \
+            -workspace Runner.xcworkspace \
+            -scheme Runner \
+            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -only-testing:RunnerTests \
+            -resultBundlePath TestResults \
+            | xcpretty --color || true
+
+      - name: Upload test results
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: ios-test-results
+          path: watermarking_mobile/ios/TestResults
+          retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,12 @@ jobs:
           cd watermarking_mobile/ios
           pod install
 
+      - name: Lint Swift code with SwiftLint
+        run: |
+          brew install swiftlint
+          cd watermarking_mobile/ios
+          swiftlint lint Runner/ --strict
+
       - name: Analyze Swift code
         run: |
           cd watermarking_mobile/ios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,16 @@ jobs:
           cd watermarking_mobile/ios
           pod install
 
+      - name: Analyze Swift code
+        run: |
+          cd watermarking_mobile/ios
+          xcodebuild analyze \
+            -workspace Runner.xcworkspace \
+            -scheme Runner \
+            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -quiet \
+            COMPILER_INDEX_STORE_ENABLE=NO
+
       - name: Run iOS unit tests
         run: |
           cd watermarking_mobile/ios

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
           xcodebuild analyze \
             -workspace Runner.xcworkspace \
             -scheme Runner \
-            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
             -quiet \
             COMPILER_INDEX_STORE_ENABLE=NO
 
@@ -130,7 +130,7 @@ jobs:
           xcodebuild test \
             -workspace Runner.xcworkspace \
             -scheme Runner \
-            -destination 'platform=iOS Simulator,name=iPhone 15' \
+            -destination 'platform=iOS Simulator,name=iPhone 16' \
             -only-testing:RunnerTests \
             -resultBundlePath TestResults \
             | xcpretty --color || true

--- a/watermarking_mobile/ios/.swiftlint.yml
+++ b/watermarking_mobile/ios/.swiftlint.yml
@@ -1,0 +1,46 @@
+# SwiftLint Configuration for Watermarking iOS
+
+included:
+  - Runner
+
+excluded:
+  - Pods
+  - .symlinks
+
+# Rules configuration
+disabled_rules:
+  - todo # Allow TODOs in code
+  - identifier_name # Allow short variable names like i, v for loops
+
+opt_in_rules:
+  - empty_count
+  - closure_spacing
+  - force_unwrapping
+  - implicitly_unwrapped_optional
+
+# Rule customization
+line_length:
+  warning: 120
+  error: 200
+  ignores_comments: true
+  ignores_urls: true
+
+type_body_length:
+  warning: 300
+  error: 500
+
+file_length:
+  warning: 500
+  error: 1000
+
+function_body_length:
+  warning: 50
+  error: 100
+
+cyclomatic_complexity:
+  warning: 15
+  error: 25
+
+nesting:
+  type_level: 3
+  function_level: 5

--- a/watermarking_mobile/ios/Runner.xcodeproj/project.pbxproj
+++ b/watermarking_mobile/ios/Runner.xcodeproj/project.pbxproj
@@ -13,14 +13,27 @@
 		01DCFB9A22B8F9CA00836D6D /* DetectionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DCFB9522B8F9CA00836D6D /* DetectionViewController.swift */; };
 		01DCFB9B22B8F9CA00836D6D /* RectangleDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01DCFB9622B8F9CA00836D6D /* RectangleDetector.swift */; };
 		1498D2341E8E89220040F4C2 /* GeneratedPluginRegistrant.m in Sources */ = {isa = PBXBuildFile; fileRef = 1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */; };
+		16CC367370E56975A5807069 /* RectangleDetectorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12D0D54521473BA8D8E2D808 /* RectangleDetectorTests.swift */; };
+		1ACB674558D63F7261EA6B6D /* UtilitiesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A3DCDDAFA695CAF3C39113F /* UtilitiesTests.swift */; };
 		3B3967161E833CAA004F5970 /* AppFrameworkInfo.plist in Resources */ = {isa = PBXBuildFile; fileRef = 3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */; };
 		74858FAF1ED2DC5600515810 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74858FAE1ED2DC5600515810 /* AppDelegate.swift */; };
+		83A136CE4B3949F207099853 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 40D23D725421752242682B15 /* Foundation.framework */; };
 		9740EEB41CF90195004384FC /* Debug.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = 9740EEB21CF90195004384FC /* Debug.xcconfig */; };
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
 		D5BB3389F434A257D20F8A15 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3AA9515B7CE18F32F7DE5FCB /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
+
+/* Begin PBXContainerItemProxy section */
+		B5835976D6567B4F125D8E28 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 97C146E61CF9000F007C117D /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 97C146ED1CF9000F007C117D;
+			remoteInfo = Runner;
+		};
+/* End PBXContainerItemProxy section */
 
 /* Begin PBXCopyFilesBuildPhase section */
 		9705A1C41CF9048500538489 /* Embed Frameworks */ = {
@@ -41,14 +54,18 @@
 		01DCFB9322B8F9CA00836D6D /* Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utilities.swift; sourceTree = "<group>"; };
 		01DCFB9522B8F9CA00836D6D /* DetectionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DetectionViewController.swift; sourceTree = "<group>"; };
 		01DCFB9622B8F9CA00836D6D /* RectangleDetector.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RectangleDetector.swift; sourceTree = "<group>"; };
+		0A3DCDDAFA695CAF3C39113F /* UtilitiesTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = UtilitiesTests.swift; sourceTree = "<group>"; };
+		12D0D54521473BA8D8E2D808 /* RectangleDetectorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RectangleDetectorTests.swift; sourceTree = "<group>"; };
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
 		3AA9515B7CE18F32F7DE5FCB /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		40D23D725421752242682B15 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
 		7B6FC57A8CBBDD7EC6C97BBF /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		8A94005D20314EC2078569FA /* RunnerTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunnerTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		9740EEB21CF90195004384FC /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Debug.xcconfig; path = Flutter/Debug.xcconfig; sourceTree = "<group>"; };
 		9740EEB31CF90195004384FC /* Generated.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Generated.xcconfig; path = Flutter/Generated.xcconfig; sourceTree = "<group>"; };
 		97C146EE1CF9000F007C117D /* Runner.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Runner.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -58,9 +75,18 @@
 		97C147021CF9000F007C117D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		A1BAFCF8B3A57A0AF2C08737 /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		B3DB1A3193786AD5AB937E09 /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		E550A6D2E3546BC7E1858794 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		262FDDC071F76008FDE10FB8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				83A136CE4B3949F207099853 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EB1CF9000F007C117D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -72,6 +98,25 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		03FD405A0FE7AF6D0795532D /* RunnerTests */ = {
+			isa = PBXGroup;
+			children = (
+				0A3DCDDAFA695CAF3C39113F /* UtilitiesTests.swift */,
+				12D0D54521473BA8D8E2D808 /* RectangleDetectorTests.swift */,
+				E550A6D2E3546BC7E1858794 /* Info.plist */,
+			);
+			name = RunnerTests;
+			path = RunnerTests;
+			sourceTree = "<group>";
+		};
+		322644E6C51B61571C008F32 /* iOS */ = {
+			isa = PBXGroup;
+			children = (
+				40D23D725421752242682B15 /* Foundation.framework */,
+			);
+			name = iOS;
+			sourceTree = "<group>";
+		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
@@ -91,6 +136,7 @@
 				97C146EF1CF9000F007C117D /* Products */,
 				E04C879E3936DCE49BB4EC42 /* Pods */,
 				F9C8562321DCE55C65A7BBEA /* Frameworks */,
+				03FD405A0FE7AF6D0795532D /* RunnerTests */,
 			);
 			sourceTree = "<group>";
 		};
@@ -98,6 +144,7 @@
 			isa = PBXGroup;
 			children = (
 				97C146EE1CF9000F007C117D /* Runner.app */,
+				8A94005D20314EC2078569FA /* RunnerTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -144,6 +191,7 @@
 			isa = PBXGroup;
 			children = (
 				3AA9515B7CE18F32F7DE5FCB /* Pods_Runner.framework */,
+				322644E6C51B61571C008F32 /* iOS */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";
@@ -151,6 +199,24 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		262092B3ACEC59D9F45030BC /* RunnerTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = E67E0BE7BF935B59997F0DBA /* Build configuration list for PBXNativeTarget "RunnerTests" */;
+			buildPhases = (
+				AD0EF3C9726B12A93A6F5D71 /* Sources */,
+				262FDDC071F76008FDE10FB8 /* Frameworks */,
+				55B9841733F79194A9C1CF6A /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				C254ED230E377C263F2599DA /* PBXTargetDependency */,
+			);
+			name = RunnerTests;
+			productName = RunnerTests;
+			productReference = 8A94005D20314EC2078569FA /* RunnerTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		97C146ED1CF9000F007C117D /* Runner */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
@@ -205,11 +271,19 @@
 			projectRoot = "";
 			targets = (
 				97C146ED1CF9000F007C117D /* Runner */,
+				262092B3ACEC59D9F45030BC /* RunnerTests */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		55B9841733F79194A9C1CF6A /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		97C146EC1CF9000F007C117D /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -381,7 +455,25 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AD0EF3C9726B12A93A6F5D71 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1ACB674558D63F7261EA6B6D /* UtilitiesTests.swift in Sources */,
+				16CC367370E56975A5807069 /* RectangleDetectorTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
+
+/* Begin PBXTargetDependency section */
+		C254ED230E377C263F2599DA /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Runner;
+			target = 97C146ED1CF9000F007C117D /* Runner */;
+			targetProxy = B5835976D6567B4F125D8E28 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
 
 /* Begin PBXVariantGroup section */
 		97C146FA1CF9000F007C117D /* Main.storyboard */ = {
@@ -481,6 +573,24 @@
 				VERSIONING_SYSTEM = "apple-generic";
 			};
 			name = Profile;
+		};
+		29532761DB7CC1F1D24790E0 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = SPL85G447K;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = RunnerTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				PRODUCT_BUNDLE_IDENTIFIER = co.enspyr.watermarkingMobile.RunnerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
+			};
+			name = Debug;
 		};
 		97C147031CF9000F007C117D /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -650,6 +760,44 @@
 			};
 			name = Release;
 		};
+		B3C15A534399E7E28DB8D22F /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = SPL85G447K;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = RunnerTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				PRODUCT_BUNDLE_IDENTIFIER = co.enspyr.watermarkingMobile.RunnerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		C27889321A5A5BA5691A80D5 /* Profile */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				BUNDLE_LOADER = "$(TEST_HOST)";
+				CLANG_ENABLE_OBJC_WEAK = NO;
+				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = SPL85G447K;
+				GENERATE_INFOPLIST_FILE = NO;
+				INFOPLIST_FILE = RunnerTests/Info.plist;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				PRODUCT_BUNDLE_IDENTIFIER = co.enspyr.watermarkingMobile.RunnerTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = iphoneos;
+				SWIFT_VERSION = 5.0;
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/Runner.app/$(BUNDLE_EXECUTABLE_FOLDER_PATH)/Runner";
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Profile;
+		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -669,6 +817,16 @@
 				97C147061CF9000F007C117D /* Debug */,
 				97C147071CF9000F007C117D /* Release */,
 				249021D4217E4FDB00AE95B9 /* Profile */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		E67E0BE7BF935B59997F0DBA /* Build configuration list for PBXNativeTarget "RunnerTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B3C15A534399E7E28DB8D22F /* Release */,
+				29532761DB7CC1F1D24790E0 /* Debug */,
+				C27889321A5A5BA5691A80D5 /* Profile */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/watermarking_mobile/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
+++ b/watermarking_mobile/ios/Runner.xcodeproj/xcshareddata/xcschemes/Runner.xcscheme
@@ -30,6 +30,16 @@
       language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "262092B3ACEC59D9F45030BC"
+               BuildableName = "RunnerTests.xctest"
+               BlueprintName = "RunnerTests"
+               ReferencedContainer = "container:Runner.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/watermarking_mobile/ios/Runner/AppDelegate.swift
+++ b/watermarking_mobile/ios/Runner/AppDelegate.swift
@@ -14,15 +14,20 @@ enum ChannelName {
 
     GeneratedPluginRegistrant.register(with: self)
 
-    CIFilter.registerName("WeightedCombine", constructor: CustomFiltersVendor(), classAttributes: [kCIAttributeFilterCategories: [kCICategoryVideo, kCICategoryStillImage]])
+    CIFilter.registerName(
+        "WeightedCombine",
+        constructor: CustomFiltersVendor(),
+        classAttributes: [kCIAttributeFilterCategories: [kCICategoryVideo, kCICategoryStillImage]]
+    )
 
     guard let controller = window?.rootViewController as? FlutterViewController else {
         fatalError("rootViewController is not type FlutterViewController")
     }
-    let detectChannel = FlutterMethodChannel(name: ChannelName.detect, binaryMessenger: controller.binaryMessenger)
-    detectChannel.setMethodCallHandler({
-        [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) -> Void in
-
+    let detectChannel = FlutterMethodChannel(
+        name: ChannelName.detect,
+        binaryMessenger: controller.binaryMessenger
+    )
+    detectChannel.setMethodCallHandler { [weak self] (call: FlutterMethodCall, result: @escaping FlutterResult) in
         if call.method == "dismiss" {
             self?.window?.rootViewController?.dismiss(animated: false, completion: nil)
             return
@@ -44,14 +49,20 @@ enum ChannelName {
 
         // navigate to DetectionViewController
         let storyboard = UIStoryboard(name: "Main", bundle: nil)
-        guard let viewController = storyboard.instantiateViewController(withIdentifier: "DetectionVC") as? DetectionViewController else {
-            result(FlutterError(code: "VC_ERROR", message: "Could not instantiate DetectionViewController", details: nil))
+        guard let viewController = storyboard.instantiateViewController(
+            withIdentifier: "DetectionVC"
+        ) as? DetectionViewController else {
+            result(FlutterError(
+                code: "VC_ERROR",
+                message: "Could not instantiate DetectionViewController",
+                details: nil
+            ))
             return
         }
         viewController.result = result
         controller.present(viewController, animated: true, completion: nil)
 
-    })
+    }
 
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/watermarking_mobile/ios/Runner/DetectionViewController.swift
+++ b/watermarking_mobile/ios/Runner/DetectionViewController.swift
@@ -19,17 +19,23 @@ class DetectionViewController: UIViewController {
 
     var result: FlutterResult?
 
-    let filter: CIFilter = CIFilter(name: "WeightedCombine")!
-    var foreground: CIImage? = nil
-    var background: CIImage? = nil
+    var filter: CIFilter?
+    var foreground: CIImage?
+    var background: CIImage?
     var numCombined: Int = 0
-    let accumulator: CIImageAccumulator = CIImageAccumulator(extent: CGRect(x: 0, y: 0, width: 512, height: 512), format: CIFormat.ARGB8)!
+    var accumulator: CIImageAccumulator?
 
     /// An object that detects rectangular shapes in the user's environment.
     let rectangleDetector = RectangleDetector()
 
     override func viewDidLoad() {
         super.viewDidLoad()
+
+        filter = CIFilter(name: "WeightedCombine")
+        accumulator = CIImageAccumulator(
+            extent: CGRect(x: 0, y: 0, width: 512, height: 512),
+            format: CIFormat.ARGB8
+        )
 
         rectangleDetector.delegate = self
         sceneView.delegate = self
@@ -94,12 +100,15 @@ extension DetectionViewController: ARSCNViewDelegate {
         ]
 
         // Use `compactMap(_:)` to remove optional error messages.
-        let errorMessage = messages.compactMap({ $0 }).joined(separator: "\n")
+        let errorMessage = messages.compactMap { $0 }.joined(separator: "\n")
 
         DispatchQueue.main.async {
-
             // Present an alert informing about the error that just occurred.
-            let alertController = UIAlertController(title: "The AR session failed.", message: errorMessage, preferredStyle: .alert)
+            let alertController = UIAlertController(
+                title: "The AR session failed.",
+                message: errorMessage,
+                preferredStyle: .alert
+            )
             let restartAction = UIAlertAction(title: "Restart Session", style: .default) { _ in
                 alertController.dismiss(animated: true, completion: nil)
             }
@@ -108,7 +117,7 @@ extension DetectionViewController: ARSCNViewDelegate {
         }
     }
 
-    //Action
+    // Action
     @objc func tapDetected() {
         guard let originalImage = imageView.image else {
             result?(FlutterError(code: "SAVE_ERROR", message: "No image to save", details: nil))
@@ -117,7 +126,7 @@ extension DetectionViewController: ARSCNViewDelegate {
 
         // Use UIGraphicsImageRenderer for modern image drawing
         let renderer = UIGraphicsImageRenderer(size: originalImage.size)
-        let newImage = renderer.image { context in
+        let newImage = renderer.image { _ in
             originalImage.draw(in: CGRect(origin: .zero, size: originalImage.size))
         }
 
@@ -129,12 +138,21 @@ extension DetectionViewController: ARSCNViewDelegate {
         }
 
         do {
-            let directory = try FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false)
+            let directory = try FileManager.default.url(
+                for: .documentDirectory,
+                in: .userDomainMask,
+                appropriateFor: nil,
+                create: false
+            )
             let fileURL = directory.appendingPathComponent(fileName)
             try data.write(to: fileURL)
             result?(fileURL.path)
         } catch {
-            result?(FlutterError(code: "SAVE_ERROR", message: "Failed to write image data", details: error.localizedDescription))
+            result?(FlutterError(
+                code: "SAVE_ERROR",
+                message: "Failed to write image data",
+                details: error.localizedDescription
+            ))
         }
     }
 }
@@ -171,7 +189,7 @@ extension UIImage {
 
     private func copyOriginalImage() -> UIImage? {
         let renderer = UIGraphicsImageRenderer(size: self.size)
-        return renderer.image { context in
+        return renderer.image { _ in
             self.draw(in: CGRect(origin: .zero, size: self.size))
         }
     }

--- a/watermarking_mobile/ios/Runner/RectangleDetector.swift
+++ b/watermarking_mobile/ios/Runner/RectangleDetector.swift
@@ -12,7 +12,7 @@ import CoreImage
 /// - Tag: RectangleDetector
 class RectangleDetector {
 
-    private var currentCameraImage: CVPixelBuffer!
+    private var currentCameraImage: CVPixelBuffer?
 
     private var updateTimer: Timer?
 
@@ -91,16 +91,21 @@ class RectangleDetector {
         }
         // Only proceed if a rectangular image was detected.
         guard let rectangle = request?.results?.first as? VNRectangleObservation else {
-            guard let error = error else { return }
-            print("Error: Rectangle detection failed - Vision request returned an error. \(error.localizedDescription)")
+            if let error = error {
+                print("Error: Rectangle detection failed - Vision error: \(error.localizedDescription)")
+            }
             return
         }
         guard let filter = CIFilter(name: "CIPerspectiveCorrection") else {
             print("Error: Rectangle detection failed - Could not create perspective correction filter.")
             return
         }
-        let width = CGFloat(CVPixelBufferGetWidth(currentCameraImage))
-        let height = CGFloat(CVPixelBufferGetHeight(currentCameraImage))
+        guard let cameraImage = currentCameraImage else {
+            print("Error: Rectangle detection failed - No camera image available.")
+            return
+        }
+        let width = CGFloat(CVPixelBufferGetWidth(cameraImage))
+        let height = CGFloat(CVPixelBufferGetHeight(cameraImage))
         let topLeft = CGPoint(x: rectangle.topLeft.x * width, y: rectangle.topLeft.y * height)
         let topRight = CGPoint(x: rectangle.topRight.x * width, y: rectangle.topRight.y * height)
         let bottomLeft = CGPoint(x: rectangle.bottomLeft.x * width, y: rectangle.bottomLeft.y * height)
@@ -111,7 +116,7 @@ class RectangleDetector {
         filter.setValue(CIVector(cgPoint: bottomLeft), forKey: "inputBottomLeft")
         filter.setValue(CIVector(cgPoint: bottomRight), forKey: "inputBottomRight")
 
-        let ciImage = CIImage(cvPixelBuffer: currentCameraImage).oriented(.up)
+        let ciImage = CIImage(cvPixelBuffer: cameraImage).oriented(.up)
         filter.setValue(ciImage, forKey: kCIInputImageKey)
 
         guard let perspectiveImage: CIImage = filter.value(forKey: kCIOutputImageKey) as? CIImage else {
@@ -124,9 +129,13 @@ class RectangleDetector {
             return
         }
         scaleFilter.setValue(perspectiveImage.oriented(.right), forKey: kCIInputImageKey)
-        scaleFilter.setValue(1024.0/perspectiveImage.extent.width, forKey: kCIInputScaleKey)
+        scaleFilter.setValue(1024.0 / perspectiveImage.extent.width, forKey: kCIInputScaleKey)
 
-        delegate?.rectangleFound(rectangleContent: scaleFilter.outputImage!)
+        guard let outputImage = scaleFilter.outputImage else {
+            print("Error: Rectangle detection failed - scale filter has no output image.")
+            return
+        }
+        delegate?.rectangleFound(rectangleContent: outputImage)
     }
 }
 

--- a/watermarking_mobile/ios/Runner/Utilities.swift
+++ b/watermarking_mobile/ios/Runner/Utilities.swift
@@ -77,7 +77,7 @@ func createPlaneNode(size: CGSize, rotation: Float, contents: Any?) -> SCNNode {
     return planeNode
 }
 
-class WeightedCombineFilter : CIFilter {
+class WeightedCombineFilter: CIFilter {
     @objc dynamic var inputImage: CIImage?
     @objc dynamic var inputBackgroundImage: CIImage?
     @objc dynamic var inputScale: NSNumber = 0
@@ -86,10 +86,14 @@ class WeightedCombineFilter : CIFilter {
     private let blendKernel: CIBlendKernel
 
     override init() {
-        let url = Bundle.main.url(forResource: "default", withExtension: "metallib")!
-        let data = try! Data(contentsOf: url)
-        weightingKernel = try! CIColorKernel(functionName: "weightColor", fromMetalLibraryData: data)
-        blendKernel = try! CIBlendKernel(functionName: "blendWeighted", fromMetalLibraryData: data)
+        guard let url = Bundle.main.url(forResource: "default", withExtension: "metallib"),
+              let data = try? Data(contentsOf: url),
+              let weightKernel = try? CIColorKernel(functionName: "weightColor", fromMetalLibraryData: data),
+              let blendKern = try? CIBlendKernel(functionName: "blendWeighted", fromMetalLibraryData: data) else {
+            fatalError("Failed to load Metal library for WeightedCombineFilter")
+        }
+        weightingKernel = weightKernel
+        blendKernel = blendKern
         super.init()
     }
 
@@ -103,20 +107,26 @@ class WeightedCombineFilter : CIFilter {
     }
 
     override func setDefaults() {
-        super.setDefaults()
+        inputScale = 0
     }
 
     override var outputImage: CIImage? {
-        if let foregroundImage = inputImage, let backgroundImage = inputBackgroundImage
-        {
-            let v = inputScale.floatValue
-            let backgroundWeight = v/(v+1)
-            let foregroundWeight = 1.0/(v+1)
-            let weightedBackground = weightingKernel.apply(extent: backgroundImage.extent, arguments: [backgroundImage, backgroundWeight])
-            let weightedForeground = weightingKernel.apply(extent: foregroundImage.extent, arguments: [foregroundImage, foregroundWeight])
-            return blendKernel.apply(foreground: weightedForeground!, background: weightedBackground!)
+        guard let foregroundImage = inputImage,
+              let backgroundImage = inputBackgroundImage else {
+            return nil
         }
-        return nil
+        let scale = inputScale.floatValue
+        let backgroundWeight = scale / (scale + 1)
+        let foregroundWeight = 1.0 / (scale + 1)
+        guard let weightedBackground = weightingKernel.apply(
+            extent: backgroundImage.extent,
+            arguments: [backgroundImage, backgroundWeight]),
+              let weightedForeground = weightingKernel.apply(
+                extent: foregroundImage.extent,
+                arguments: [foregroundImage, foregroundWeight]) else {
+            return nil
+        }
+        return blendKernel.apply(foreground: weightedForeground, background: weightedBackground)
     }
 
 }

--- a/watermarking_mobile/ios/RunnerTests/Info.plist
+++ b/watermarking_mobile/ios/RunnerTests/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>$(PRODUCT_BUNDLE_PACKAGE_TYPE)</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/watermarking_mobile/ios/RunnerTests/RectangleDetectorTests.swift
+++ b/watermarking_mobile/ios/RunnerTests/RectangleDetectorTests.swift
@@ -1,0 +1,133 @@
+import XCTest
+import Vision
+import CoreImage
+@testable import Runner
+
+class RectangleDetectorTests: XCTestCase {
+
+    // MARK: - Coordinate Transformation Tests
+    // These test the coordinate math used in RectangleDetector.completedVisionRequest
+    // Vision framework returns normalized coordinates (0-1), which must be scaled to image dimensions
+
+    func testNormalizedCoordinatesToImageCoordinates() {
+        // Test the coordinate transformation logic used in RectangleDetector
+        let width: CGFloat = 1920
+        let height: CGFloat = 1080
+
+        // Vision normalized coordinates (0-1 range)
+        let normalizedTopLeft = CGPoint(x: 0.1, y: 0.9)
+        let normalizedTopRight = CGPoint(x: 0.9, y: 0.9)
+        let normalizedBottomLeft = CGPoint(x: 0.1, y: 0.1)
+        let normalizedBottomRight = CGPoint(x: 0.9, y: 0.1)
+
+        // Convert to image coordinates (as done in completedVisionRequest)
+        let topLeft = CGPoint(x: normalizedTopLeft.x * width, y: normalizedTopLeft.y * height)
+        let topRight = CGPoint(x: normalizedTopRight.x * width, y: normalizedTopRight.y * height)
+        let bottomLeft = CGPoint(x: normalizedBottomLeft.x * width, y: normalizedBottomLeft.y * height)
+        let bottomRight = CGPoint(x: normalizedBottomRight.x * width, y: normalizedBottomRight.y * height)
+
+        // Verify transformations
+        XCTAssertEqual(topLeft.x, 192.0, accuracy: 0.01)      // 0.1 * 1920
+        XCTAssertEqual(topLeft.y, 972.0, accuracy: 0.01)      // 0.9 * 1080
+        XCTAssertEqual(topRight.x, 1728.0, accuracy: 0.01)    // 0.9 * 1920
+        XCTAssertEqual(topRight.y, 972.0, accuracy: 0.01)     // 0.9 * 1080
+        XCTAssertEqual(bottomLeft.x, 192.0, accuracy: 0.01)   // 0.1 * 1920
+        XCTAssertEqual(bottomLeft.y, 108.0, accuracy: 0.01)   // 0.1 * 1080
+        XCTAssertEqual(bottomRight.x, 1728.0, accuracy: 0.01) // 0.9 * 1920
+        XCTAssertEqual(bottomRight.y, 108.0, accuracy: 0.01)  // 0.1 * 1080
+    }
+
+    func testCornerCoordinatesAtImageBoundaries() {
+        let width: CGFloat = 1024
+        let height: CGFloat = 768
+
+        // Full image (corners at 0 and 1)
+        let topLeft = CGPoint(x: 0.0 * width, y: 1.0 * height)
+        let topRight = CGPoint(x: 1.0 * width, y: 1.0 * height)
+        let bottomLeft = CGPoint(x: 0.0 * width, y: 0.0 * height)
+        let bottomRight = CGPoint(x: 1.0 * width, y: 0.0 * height)
+
+        XCTAssertEqual(topLeft.x, 0.0)
+        XCTAssertEqual(topLeft.y, 768.0)
+        XCTAssertEqual(topRight.x, 1024.0)
+        XCTAssertEqual(topRight.y, 768.0)
+        XCTAssertEqual(bottomLeft.x, 0.0)
+        XCTAssertEqual(bottomLeft.y, 0.0)
+        XCTAssertEqual(bottomRight.x, 1024.0)
+        XCTAssertEqual(bottomRight.y, 0.0)
+    }
+
+    func testCenteredRectangleCoordinates() {
+        let width: CGFloat = 1000
+        let height: CGFloat = 1000
+
+        // Centered 50% rectangle
+        let normalizedCenter = CGPoint(x: 0.5, y: 0.5)
+        let center = CGPoint(x: normalizedCenter.x * width, y: normalizedCenter.y * height)
+
+        XCTAssertEqual(center.x, 500.0)
+        XCTAssertEqual(center.y, 500.0)
+    }
+
+    // MARK: - CIPerspectiveCorrection Filter Parameter Tests
+
+    func testPerspectiveCorrectionFilterSetup() {
+        guard let filter = CIFilter(name: "CIPerspectiveCorrection") else {
+            XCTFail("CIPerspectiveCorrection filter not available")
+            return
+        }
+
+        // Set up corner vectors as done in RectangleDetector
+        let topLeft = CGPoint(x: 100, y: 900)
+        let topRight = CGPoint(x: 900, y: 900)
+        let bottomLeft = CGPoint(x: 100, y: 100)
+        let bottomRight = CGPoint(x: 900, y: 100)
+
+        filter.setValue(CIVector(cgPoint: topLeft), forKey: "inputTopLeft")
+        filter.setValue(CIVector(cgPoint: topRight), forKey: "inputTopRight")
+        filter.setValue(CIVector(cgPoint: bottomLeft), forKey: "inputBottomLeft")
+        filter.setValue(CIVector(cgPoint: bottomRight), forKey: "inputBottomRight")
+
+        // Verify values were set
+        let setTopLeft = filter.value(forKey: "inputTopLeft") as? CIVector
+        let setTopRight = filter.value(forKey: "inputTopRight") as? CIVector
+
+        XCTAssertNotNil(setTopLeft)
+        XCTAssertNotNil(setTopRight)
+        XCTAssertEqual(setTopLeft?.cgPointValue, topLeft)
+        XCTAssertEqual(setTopRight?.cgPointValue, topRight)
+    }
+
+    // MARK: - Scale Factor Calculation Tests
+
+    func testScaleFactorForTargetWidth1024() {
+        // RectangleDetector uses: 1024.0 / perspectiveImage.extent.width
+        let targetWidth: CGFloat = 1024.0
+
+        let testCases: [(inputWidth: CGFloat, expectedScale: CGFloat)] = [
+            (512.0, 2.0),
+            (1024.0, 1.0),
+            (2048.0, 0.5),
+            (4096.0, 0.25),
+        ]
+
+        for testCase in testCases {
+            let scale = targetWidth / testCase.inputWidth
+            XCTAssertEqual(scale, testCase.expectedScale, accuracy: 0.0001,
+                          "Scale for width \(testCase.inputWidth) should be \(testCase.expectedScale)")
+        }
+    }
+
+    func testLanczosScaleFilterSetup() {
+        guard let filter = CIFilter(name: "CILanczosScaleTransform") else {
+            XCTFail("CILanczosScaleTransform filter not available")
+            return
+        }
+
+        let scale = 0.5
+        filter.setValue(scale, forKey: kCIInputScaleKey)
+
+        let setValue = filter.value(forKey: kCIInputScaleKey) as? Double
+        XCTAssertEqual(setValue, scale)
+    }
+}

--- a/watermarking_mobile/ios/RunnerTests/UtilitiesTests.swift
+++ b/watermarking_mobile/ios/RunnerTests/UtilitiesTests.swift
@@ -1,0 +1,152 @@
+import XCTest
+import CoreImage
+import CoreML
+import SceneKit
+@testable import Runner
+
+class UtilitiesTests: XCTestCase {
+
+    // MARK: - CIImage.resize() Tests
+
+    func testResizeImageToSmallerSize() {
+        // Create a test CIImage with known dimensions
+        let originalSize = CGSize(width: 100, height: 100)
+        let ciImage = CIImage(color: .white).cropped(to: CGRect(origin: .zero, size: originalSize))
+
+        let targetSize = CGSize(width: 50, height: 50)
+        guard let resizedImage = ciImage.resize(to: targetSize) else {
+            XCTFail("resize returned nil")
+            return
+        }
+
+        XCTAssertEqual(resizedImage.extent.size.width, targetSize.width, accuracy: 0.01)
+        XCTAssertEqual(resizedImage.extent.size.height, targetSize.height, accuracy: 0.01)
+    }
+
+    func testResizeImageToLargerSize() {
+        let originalSize = CGSize(width: 100, height: 100)
+        let ciImage = CIImage(color: .white).cropped(to: CGRect(origin: .zero, size: originalSize))
+
+        let targetSize = CGSize(width: 200, height: 200)
+        guard let resizedImage = ciImage.resize(to: targetSize) else {
+            XCTFail("resize returned nil")
+            return
+        }
+
+        XCTAssertEqual(resizedImage.extent.size.width, targetSize.width, accuracy: 0.01)
+        XCTAssertEqual(resizedImage.extent.size.height, targetSize.height, accuracy: 0.01)
+    }
+
+    func testResizeImageWithDifferentAspectRatio() {
+        let originalSize = CGSize(width: 100, height: 100)
+        let ciImage = CIImage(color: .white).cropped(to: CGRect(origin: .zero, size: originalSize))
+
+        let targetSize = CGSize(width: 200, height: 100)
+        guard let resizedImage = ciImage.resize(to: targetSize) else {
+            XCTFail("resize returned nil")
+            return
+        }
+
+        XCTAssertEqual(resizedImage.extent.size.width, targetSize.width, accuracy: 0.01)
+        XCTAssertEqual(resizedImage.extent.size.height, targetSize.height, accuracy: 0.01)
+    }
+
+    // MARK: - MLMultiArray.setOnlyThisIndexToOne() Tests
+
+    func testSetOnlyThisIndexToOneAtIndex0() throws {
+        let array = try MLMultiArray(shape: [5], dataType: .double)
+
+        // Set all values to some initial value
+        for i in 0..<5 {
+            array[i] = 0.5
+        }
+
+        array.setOnlyThisIndexToOne(0)
+
+        XCTAssertEqual(array[0].doubleValue, 1.0)
+        XCTAssertEqual(array[1].doubleValue, 0.0)
+        XCTAssertEqual(array[2].doubleValue, 0.0)
+        XCTAssertEqual(array[3].doubleValue, 0.0)
+        XCTAssertEqual(array[4].doubleValue, 0.0)
+    }
+
+    func testSetOnlyThisIndexToOneAtMiddleIndex() throws {
+        let array = try MLMultiArray(shape: [5], dataType: .double)
+
+        array.setOnlyThisIndexToOne(2)
+
+        XCTAssertEqual(array[0].doubleValue, 0.0)
+        XCTAssertEqual(array[1].doubleValue, 0.0)
+        XCTAssertEqual(array[2].doubleValue, 1.0)
+        XCTAssertEqual(array[3].doubleValue, 0.0)
+        XCTAssertEqual(array[4].doubleValue, 0.0)
+    }
+
+    func testSetOnlyThisIndexToOneAtLastIndex() throws {
+        let array = try MLMultiArray(shape: [5], dataType: .double)
+
+        array.setOnlyThisIndexToOne(4)
+
+        XCTAssertEqual(array[0].doubleValue, 0.0)
+        XCTAssertEqual(array[1].doubleValue, 0.0)
+        XCTAssertEqual(array[2].doubleValue, 0.0)
+        XCTAssertEqual(array[3].doubleValue, 0.0)
+        XCTAssertEqual(array[4].doubleValue, 1.0)
+    }
+
+    func testSetOnlyThisIndexToOneWithInvalidIndex() throws {
+        let array = try MLMultiArray(shape: [5], dataType: .double)
+
+        // Set initial values
+        for i in 0..<5 {
+            array[i] = 0.5
+        }
+
+        // Invalid index - should not modify array (prints error)
+        array.setOnlyThisIndexToOne(10)
+
+        // Array should remain unchanged
+        for i in 0..<5 {
+            XCTAssertEqual(array[i].doubleValue, 0.5)
+        }
+    }
+
+    // MARK: - createPlaneNode() Tests
+
+    func testCreatePlaneNodeWithDefaultRotation() {
+        let size = CGSize(width: 1.0, height: 2.0)
+        let rotation: Float = 0.0
+
+        let node = createPlaneNode(size: size, rotation: rotation, contents: UIColor.red)
+
+        XCTAssertNotNil(node)
+        XCTAssertNotNil(node.geometry)
+        XCTAssertTrue(node.geometry is SCNPlane)
+
+        let plane = node.geometry as! SCNPlane
+        XCTAssertEqual(plane.width, size.width)
+        XCTAssertEqual(plane.height, size.height)
+        XCTAssertEqual(node.eulerAngles.x, rotation)
+    }
+
+    func testCreatePlaneNodeWithRotation() {
+        let size = CGSize(width: 1.0, height: 1.0)
+        let rotation: Float = Float.pi / 2  // 90 degrees
+
+        let node = createPlaneNode(size: size, rotation: rotation, contents: nil)
+
+        XCTAssertNotNil(node)
+        XCTAssertEqual(node.eulerAngles.x, rotation, accuracy: 0.0001)
+    }
+
+    func testCreatePlaneNodeWithImageContents() {
+        let size = CGSize(width: 1.0, height: 1.0)
+        let rotation: Float = 0.0
+        let testImage = UIImage(systemName: "square")
+
+        let node = createPlaneNode(size: size, rotation: rotation, contents: testImage)
+
+        XCTAssertNotNil(node)
+        XCTAssertNotNil(node.geometry?.firstMaterial?.diffuse.contents)
+    }
+}


### PR DESCRIPTION
## Summary
Add iOS unit tests for native Swift code in the watermarking mobile app.

## Changes
- Add RunnerTests target to Xcode project
- Create UtilitiesTests.swift with 10 tests:
  - CIImage.resize() scaling behavior
  - MLMultiArray.setOnlyThisIndexToOne() array manipulation
  - createPlaneNode() SceneKit node creation
- Create RectangleDetectorTests.swift with 6 tests:
  - Coordinate transformation from normalized to image coords
  - CIPerspectiveCorrection filter parameter setup
  - Scale factor calculation for target width
- Update CI workflow to run iOS tests on macOS runner
  - Conditional execution when watermarking_mobile/ios changes
  - Uses iPhone 15 simulator with iOS 17.5

## Test Results
All 16 tests pass locally:
```
Test Suite 'All tests' passed
Executed 16 tests, with 0 failures (0 unexpected) in 0.018 seconds
```