### PR TITLE
feat(api): add REST API for watermarking images

### DIFF
--- a/watermarking-api/.dockerignore
+++ b/watermarking-api/.dockerignore
@@ -1,0 +1,7 @@
+node_modules
+npm-debug.log
+.env
+.git
+.gitignore
+*.md
+.DS_Store

--- a/watermarking-api/.env.example
+++ b/watermarking-api/.env.example
@@ -1,0 +1,8 @@
+# Required: API key for authentication
+API_KEY=your-secret-api-key-here
+
+# Optional: Server port (default: 8080)
+PORT=8080
+
+# Optional: Default watermark strength 1-100 (default: 10)
+DEFAULT_STRENGTH=10

--- a/watermarking-api/.gitignore
+++ b/watermarking-api/.gitignore
@@ -1,0 +1,12 @@
+# Dependencies
+node_modules/
+
+# Environment
+.env
+
+# OS files
+.DS_Store
+
+# Build artifacts (copied from sibling directories for Docker build)
+watermarking-functions/
+mark.cpp

--- a/watermarking-api/Dockerfile
+++ b/watermarking-api/Dockerfile
@@ -1,0 +1,76 @@
+# Dockerfile for Watermarking API
+# Multi-stage build: compile C++ binary, then run with Node.js
+
+# =============================================================================
+# Stage 1: Build the C++ mark-image binary
+# =============================================================================
+FROM ubuntu:22.04 AS builder
+
+# Prevent interactive prompts during build
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    cmake \
+    pkg-config \
+    libopencv-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Copy C++ source files
+COPY mark.cpp /build/mark.cpp
+COPY watermarking-functions /build/watermarking-functions
+
+# Compile the marking program
+RUN g++ mark.cpp -std=c++11 \
+    watermarking-functions/WatermarkDetection.cpp \
+    watermarking-functions/Utilities.cpp \
+    -I. -I/usr/include -I/usr/include/opencv4 \
+    -L/usr/lib/x86_64-linux-gnu \
+    -lopencv_core -lopencv_imgcodecs -lopencv_imgproc \
+    -o mark-image
+
+# =============================================================================
+# Stage 2: Runtime with Node.js
+# =============================================================================
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y \
+    # OpenCV runtime libraries
+    libopencv-core4.5d \
+    libopencv-imgcodecs4.5d \
+    libopencv-imgproc4.5d \
+    # Node.js
+    curl \
+    ca-certificates \
+    gnupg \
+    && curl -fsSL https://deb.nodesource.com/setup_20.x | bash - \
+    && apt-get install -y nodejs \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Copy compiled binary from builder
+COPY --from=builder /build/mark-image /app/mark-image
+
+# Copy Node.js package files and install dependencies
+COPY package.json /app/package.json
+RUN npm install --production
+
+# Copy server code
+COPY server.js /app/server.js
+
+# Create temp directories
+RUN mkdir -p /tmp/uploads
+
+# Cloud Run expects PORT environment variable
+ENV PORT=8080
+
+EXPOSE 8080
+
+CMD ["node", "server.js"]

--- a/watermarking-api/build.sh
+++ b/watermarking-api/build.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Build script for Watermarking API Docker image
+# This copies C++ source files from sibling directories and builds the image
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PARENT_DIR="$(dirname "$SCRIPT_DIR")"
+
+echo "Copying C++ source files..."
+
+# Copy mark.cpp from watermarking-docker
+cp "$PARENT_DIR/watermarking-docker/mark.cpp" "$SCRIPT_DIR/"
+
+# Copy watermarking-functions directory
+rm -rf "$SCRIPT_DIR/watermarking-functions"
+cp -r "$PARENT_DIR/watermarking-functions" "$SCRIPT_DIR/"
+
+echo "Building Docker image..."
+docker build -t watermarking-api "$SCRIPT_DIR"
+
+echo "Build complete!"
+echo ""
+echo "To run the API:"
+echo "  docker run -p 8080:8080 -e API_KEY=your-secret-key watermarking-api"

--- a/watermarking-api/package.json
+++ b/watermarking-api/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "watermarking-api",
+  "version": "1.0.0",
+  "description": "REST API for watermarking images",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2",
+    "multer": "^1.4.5-lts.1",
+    "uuid": "^9.0.0"
+  }
+}

--- a/watermarking-api/server.js
+++ b/watermarking-api/server.js
@@ -1,0 +1,289 @@
+// server.js
+// Watermarking REST API with SSE progress streaming
+
+const express = require('express');
+const multer = require('multer');
+const { v4: uuidv4 } = require('uuid');
+const { spawn } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+
+// Configuration
+const PORT = process.env.PORT || 8080;
+const API_KEY = process.env.API_KEY;
+const DEFAULT_STRENGTH = parseInt(process.env.DEFAULT_STRENGTH, 10) || 10;
+const JOB_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+// Validate API_KEY is set
+if (!API_KEY) {
+  console.error('ERROR: API_KEY environment variable is required');
+  process.exit(1);
+}
+
+// In-memory job storage
+const jobs = new Map();
+
+// Cleanup expired jobs periodically
+setInterval(() => {
+  const now = Date.now();
+  for (const [jobId, job] of jobs.entries()) {
+    if (now - job.createdAt > JOB_TTL_MS) {
+      // Clean up the file
+      if (job.markedImagePath && fs.existsSync(job.markedImagePath)) {
+        try {
+          fs.unlinkSync(job.markedImagePath);
+          console.log(`Cleaned up expired job file: ${job.markedImagePath}`);
+        } catch (err) {
+          console.error(`Error cleaning up file ${job.markedImagePath}:`, err);
+        }
+      }
+      jobs.delete(jobId);
+      console.log(`Expired job removed: ${jobId}`);
+    }
+  }
+}, 60 * 1000); // Check every minute
+
+// Configure multer for file uploads
+const upload = multer({
+  dest: '/tmp/uploads/',
+  limits: {
+    fileSize: 50 * 1024 * 1024, // 50MB limit
+  },
+  fileFilter: (req, file, cb) => {
+    const allowedMimes = ['image/png', 'image/jpeg', 'image/jpg'];
+    if (allowedMimes.includes(file.mimetype)) {
+      cb(null, true);
+    } else {
+      cb(new Error('Invalid file type. Only PNG and JPG images are allowed.'));
+    }
+  }
+});
+
+// API key authentication middleware
+function authenticateApiKey(req, res, next) {
+  const apiKey = req.headers['x-api-key'];
+
+  if (!apiKey) {
+    return res.status(401).json({ error: 'Missing X-API-Key header' });
+  }
+
+  if (apiKey !== API_KEY) {
+    return res.status(401).json({ error: 'Invalid API key' });
+  }
+
+  next();
+}
+
+// Health check endpoint (no auth required)
+app.get('/health', (req, res) => {
+  res.json({ status: 'ok' });
+});
+
+// Parse progress from C++ binary stdout
+function parseProgress(line) {
+  if (!line.startsWith('PROGRESS:')) {
+    return null;
+  }
+
+  const parts = line.substring(9).split(':');
+  const step = parts[0];
+
+  if (step === 'loading') {
+    return { progress: 'Loading image...', percent: 10 };
+  } else if (step === 'marking') {
+    const current = parseInt(parts[1], 10);
+    const total = parseInt(parts[2], 10);
+    const percent = Math.round(10 + (current / total) * 70);
+    return { progress: `Embedding watermark (${current}/${total})`, percent };
+  } else if (step === 'saving') {
+    return { progress: 'Compressing image...', percent: 90 };
+  }
+
+  return null;
+}
+
+// Watermark endpoint with SSE streaming
+app.post('/watermark', authenticateApiKey, upload.single('image'), async (req, res) => {
+  // Validate required fields
+  if (!req.file) {
+    return res.status(400).json({ error: 'Missing required field: image' });
+  }
+
+  if (!req.body.message) {
+    // Clean up uploaded file
+    if (req.file && req.file.path) {
+      fs.unlinkSync(req.file.path);
+    }
+    return res.status(400).json({ error: 'Missing required field: message' });
+  }
+
+  const message = req.body.message;
+  const strength = parseInt(req.body.strength, 10) || DEFAULT_STRENGTH;
+
+  // Validate strength range
+  if (strength < 1 || strength > 100) {
+    if (req.file && req.file.path) {
+      fs.unlinkSync(req.file.path);
+    }
+    return res.status(400).json({ error: 'Strength must be between 1 and 100' });
+  }
+
+  const jobId = uuidv4();
+  const inputPath = req.file.path;
+  const imageName = req.file.originalname || 'image';
+
+  // Set up SSE response
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no'); // Disable nginx buffering
+  res.flushHeaders();
+
+  // Helper to send SSE event
+  const sendEvent = (data) => {
+    res.write(`data: ${JSON.stringify(data)}\n\n`);
+  };
+
+  console.log(`Starting watermark job ${jobId}: message="${message}", strength=${strength}`);
+
+  // Spawn the mark-image binary
+  const markProcess = spawn('./mark-image', [
+    inputPath,
+    imageName,
+    message,
+    String(strength)
+  ]);
+
+  let lastProgress = null;
+
+  markProcess.stdout.on('data', (data) => {
+    const lines = data.toString().split('\n').filter(line => line.trim());
+    for (const line of lines) {
+      console.log(`[${jobId}] Mark output:`, line);
+      const progressData = parseProgress(line);
+      if (progressData && JSON.stringify(progressData) !== JSON.stringify(lastProgress)) {
+        lastProgress = progressData;
+        sendEvent(progressData);
+      }
+    }
+  });
+
+  markProcess.stderr.on('data', (data) => {
+    console.error(`[${jobId}] Mark stderr:`, data.toString());
+  });
+
+  markProcess.on('close', (code) => {
+    // Clean up input file
+    try {
+      if (fs.existsSync(inputPath)) {
+        fs.unlinkSync(inputPath);
+      }
+    } catch (err) {
+      console.error(`[${jobId}] Error cleaning up input file:`, err);
+    }
+
+    if (code === 0) {
+      const markedImagePath = `${inputPath}-marked.png`;
+
+      if (fs.existsSync(markedImagePath)) {
+        // Store job for download
+        jobs.set(jobId, {
+          markedImagePath,
+          createdAt: Date.now()
+        });
+
+        console.log(`[${jobId}] Watermarking complete, file: ${markedImagePath}`);
+        sendEvent({ complete: true, downloadUrl: `/download/${jobId}` });
+      } else {
+        console.error(`[${jobId}] Marked image not found at expected path`);
+        sendEvent({ error: 'Processing completed but output file not found' });
+      }
+    } else {
+      console.error(`[${jobId}] mark-image exited with code ${code}`);
+      sendEvent({ error: 'Processing failed' });
+    }
+
+    res.end();
+  });
+
+  markProcess.on('error', (err) => {
+    console.error(`[${jobId}] Process error:`, err);
+    sendEvent({ error: 'Failed to start processing' });
+    res.end();
+
+    // Clean up input file
+    try {
+      if (fs.existsSync(inputPath)) {
+        fs.unlinkSync(inputPath);
+      }
+    } catch (cleanupErr) {
+      console.error(`[${jobId}] Error cleaning up input file:`, cleanupErr);
+    }
+  });
+
+  // Handle client disconnect
+  req.on('close', () => {
+    if (!markProcess.killed) {
+      console.log(`[${jobId}] Client disconnected, killing process`);
+      markProcess.kill();
+    }
+  });
+});
+
+// Download endpoint
+app.get('/download/:jobId', authenticateApiKey, (req, res) => {
+  const jobId = req.params.jobId;
+  const job = jobs.get(jobId);
+
+  if (!job) {
+    return res.status(404).json({ error: 'Job not found or expired' });
+  }
+
+  if (!fs.existsSync(job.markedImagePath)) {
+    jobs.delete(jobId);
+    return res.status(404).json({ error: 'File not found' });
+  }
+
+  res.setHeader('Content-Type', 'image/png');
+  res.setHeader('Content-Disposition', `attachment; filename="watermarked-${jobId}.png"`);
+
+  const fileStream = fs.createReadStream(job.markedImagePath);
+  fileStream.pipe(res);
+
+  fileStream.on('error', (err) => {
+    console.error(`Error streaming file for job ${jobId}:`, err);
+    if (!res.headersSent) {
+      res.status(500).json({ error: 'Error reading file' });
+    }
+  });
+});
+
+// Error handling middleware
+app.use((err, req, res, next) => {
+  console.error('Unhandled error:', err);
+
+  // Clean up uploaded file on error
+  if (req.file && req.file.path && fs.existsSync(req.file.path)) {
+    try {
+      fs.unlinkSync(req.file.path);
+    } catch (cleanupErr) {
+      console.error('Error cleaning up file:', cleanupErr);
+    }
+  }
+
+  if (err instanceof multer.MulterError) {
+    if (err.code === 'LIMIT_FILE_SIZE') {
+      return res.status(400).json({ error: 'File too large. Maximum size is 50MB.' });
+    }
+    return res.status(400).json({ error: err.message });
+  }
+
+  res.status(500).json({ error: err.message || 'Internal server error' });
+});
+
+// Start server
+app.listen(PORT, () => {
+  console.log(`Watermarking API server running on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- Add standalone REST API service for watermarking images
- POST /watermark endpoint with SSE progress streaming
- GET /download/:jobId endpoint with 5-minute TTL
- API key authentication via X-API-Key header
- Multi-stage Docker build (C++ binary + Node.js runtime)

## Test plan
- [ ] Start Docker
- [ ] Run `./build.sh` to build the image
- [ ] Run `docker run -p 8080:8080 -e API_KEY=test123 watermarking-api`
- [ ] Test health endpoint: `curl http://localhost:8080/health`
- [ ] Test watermark endpoint with SSE streaming
- [ ] Verify download endpoint returns watermarked PNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)