### PR TITLE
fix(api): add libboost-all-dev to Docker build

### DIFF
--- a/watermarking-api/Dockerfile
+++ b/watermarking-api/Dockerfile
@@ -15,6 +15,7 @@ RUN apt-get update && apt-get install -y \
     cmake \
     pkg-config \
     libopencv-dev \
+    libboost-all-dev \
     && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /build


### PR DESCRIPTION
## Summary
Add missing Boost dependency to Dockerfile builder stage.

Required for C++ compilation of watermarking functions that use:
- `boost/multiprecision/cpp_int.hpp`
- `boost/math/special_functions/prime.hpp`

## Tested
- Docker build succeeds
- API health check works
- Watermark endpoint streams progress correctly
- Download returns valid PNG
- Rate limiting works (429 after 10 requests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)