### PR TITLE
fix(ci): only run tests when relevant code changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,24 @@ name: CI
 on:
   push:
     branches: [main]
+    paths:
+      - 'watermarking-docker/**'
+      - 'watermarking-api/**'
+      - 'watermarking_core/**'
+      - 'watermarking_mobile/**'
+      - 'watermarking_webapp/**'
+      - 'watermarking-functions/**'
+      - '.github/workflows/**'
   pull_request:
     branches: [main]
+    paths:
+      - 'watermarking-docker/**'
+      - 'watermarking-api/**'
+      - 'watermarking_core/**'
+      - 'watermarking_mobile/**'
+      - 'watermarking_webapp/**'
+      - 'watermarking-functions/**'
+      - '.github/workflows/**'
 
 jobs:
   analyze-and-test:
@@ -38,6 +54,7 @@ jobs:
 
           # Check which areas changed
           echo "docker=$([[ "$CHANGED" == *"watermarking-docker/"* ]] && echo true || echo false)" >> $GITHUB_OUTPUT
+          echo "api=$([[ "$CHANGED" == *"watermarking-api/"* ]] && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "dart=$([[ "$CHANGED" == *"watermarking_core/"* || "$CHANGED" == *"watermarking_mobile/"* || "$CHANGED" == *"watermarking_webapp/"* ]] && echo true || echo false)" >> $GITHUB_OUTPUT
           echo "ios=$([[ "$CHANGED" == *"watermarking_mobile/ios/"* ]] && echo true || echo false)" >> $GITHUB_OUTPUT
 


### PR DESCRIPTION
## Summary
- Add path filters to CI workflow - only triggers for code changes
- Skip CI entirely for docs-only changes (CLAUDE.md, README, etc.)
- Add detection for watermarking-api changes
- Updated ruleset to not require strict status checks

## Paths that trigger CI:
- `watermarking-docker/**`
- `watermarking-api/**`
- `watermarking_core/**`
- `watermarking_mobile/**`
- `watermarking_webapp/**`
- `watermarking-functions/**`
- `.github/workflows/**`

🤖 Generated with [Claude Code](https://claude.com/claude-code)