### PR TITLE
fix(api): use correct watermarking-functions source directory

### DIFF
--- a/watermarking-api/.gitignore
+++ b/watermarking-api/.gitignore
@@ -10,3 +10,4 @@ node_modules/
 # Build artifacts (copied from sibling directories for Docker build)
 watermarking-functions/
 mark.cpp
+detect.cpp

--- a/watermarking-api/build.sh
+++ b/watermarking-api/build.sh
@@ -13,9 +13,9 @@ echo "Copying C++ source files..."
 cp "$PARENT_DIR/watermarking-docker/mark.cpp" "$SCRIPT_DIR/"
 cp "$PARENT_DIR/watermarking-docker/detect.cpp" "$SCRIPT_DIR/"
 
-# Copy watermarking-functions directory
+# Copy watermarking-functions directory (from watermarking-docker which has extended detection types)
 rm -rf "$SCRIPT_DIR/watermarking-functions"
-cp -r "$PARENT_DIR/watermarking-functions" "$SCRIPT_DIR/"
+cp -r "$PARENT_DIR/watermarking-docker/watermarking-functions" "$SCRIPT_DIR/"
 
 echo "Building Docker image..."
 docker build -t watermarking-api "$SCRIPT_DIR"


### PR DESCRIPTION
## Summary
- Uses `watermarking-docker/watermarking-functions/` for API builds (has extended detection types)
- Adds `detect.cpp` to `.gitignore` (build artifact)

## Context
The root `watermarking-functions/` directory lacks extended detection types (`DetectionStats`, `SequenceStats`) needed for the `/detect` endpoint. The `watermarking-docker` version has these types for the visualization charts.

## Test plan
- [x] Verified local build with `./build.sh`
- [x] Deployed successfully to Cloud Run
- [x] Health check passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)