### PR TITLE
fix(console): revert stream sharing to fix tab spinner bug

### DIFF
--- a/watermarking_webapp/build_web.sh
+++ b/watermarking_webapp/build_web.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 flutter build web --release --source-maps \
   --dart-define=DISCORD_CLIENT_ID=1454401130611216507 \
-  --dart-define=AUTH_FUNCTION_URL=https://watermarking-auth.deno.dev
+  --dart-define=AUTH_FUNCTION_URL=https://watermarking-auth.deno.dev \
+  --dart-define=WATERMARKING_API_KEY=${WATERMARKING_API_KEY} \
+  --dart-define=WATERMARKING_API_URL=https://watermarking-api-78940960204.us-central1.run.app

--- a/watermarking_webapp/lib/views/console_dialog.dart
+++ b/watermarking_webapp/lib/views/console_dialog.dart
@@ -33,47 +33,15 @@ class ConsoleDialog extends StatelessWidget {
   }
 }
 
-class _ConsoleContent extends StatefulWidget {
+class _ConsoleContent extends StatelessWidget {
   const _ConsoleContent({required this.userId, required this.problems});
 
   final String userId;
   final List<Problem> problems;
 
   @override
-  State<_ConsoleContent> createState() => _ConsoleContentState();
-}
-
-class _ConsoleContentState extends State<_ConsoleContent> {
-  late final Stream<QuerySnapshot> _originalsStream;
-  late final Stream<QuerySnapshot> _markedStream;
-  late final Stream<QuerySnapshot> _detectionsStream;
-  late final Stream<QuerySnapshot> _tasksStream;
-
-  @override
-  void initState() {
-    super.initState();
-    final db = FirebaseFirestore.instance;
-    _originalsStream = db
-        .collection('originalImages')
-        .where('userId', isEqualTo: widget.userId)
-        .snapshots();
-    _markedStream = db
-        .collection('markedImages')
-        .where('userId', isEqualTo: widget.userId)
-        .snapshots();
-    _detectionsStream = db
-        .collection('detectionItems')
-        .where('userId', isEqualTo: widget.userId)
-        .snapshots();
-    _tasksStream = db
-        .collection('tasks')
-        .where('userId', isEqualTo: widget.userId)
-        .orderBy('createdAt', descending: true)
-        .snapshots();
-  }
-
-  @override
   Widget build(BuildContext context) {
+    final db = FirebaseFirestore.instance;
     return Dialog.fullscreen(
       child: DefaultTabController(
         length: 5,
@@ -87,18 +55,18 @@ class _ConsoleContentState extends State<_ConsoleContent> {
             bottom: TabBar(
               isScrollable: true,
               tabs: [
-                _badgeTab(_originalsStream, 'Originals'),
-                _badgeTab(_markedStream, 'Marked'),
-                _badgeTab(_detectionsStream, 'Detections'),
-                _badgeTab(_tasksStream, 'Tasks'),
+                _badgeTab(db, 'originalImages', 'Originals'),
+                _badgeTab(db, 'markedImages', 'Marked'),
+                _badgeTab(db, 'detectionItems', 'Detections'),
+                _badgeTab(db, 'tasks', 'Tasks'),
                 Tab(
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
                       const Text('Problems'),
-                      if (widget.problems.isNotEmpty) ...[
+                      if (problems.isNotEmpty) ...[
                         const SizedBox(width: 6),
-                        _badge(widget.problems.length, Colors.red),
+                        _badge(problems.length, Colors.red),
                       ],
                     ],
                   ),
@@ -109,12 +77,18 @@ class _ConsoleContentState extends State<_ConsoleContent> {
           body: TabBarView(
             children: [
               _CollectionTab(
-                stream: _originalsStream,
+                stream: db
+                    .collection('originalImages')
+                    .where('userId', isEqualTo: userId)
+                    .snapshots(),
                 imageUrlKeys: const ['servingUrl', 'url'],
                 summaryBuilder: (data) => data['name'] ?? data['path'] ?? '—',
               ),
               _CollectionTab(
-                stream: _markedStream,
+                stream: db
+                    .collection('markedImages')
+                    .where('userId', isEqualTo: userId)
+                    .snapshots(),
                 imageUrlKeys: const ['servingUrl'],
                 summaryBuilder: (data) {
                   final msg = data['message'] ?? '';
@@ -123,7 +97,10 @@ class _ConsoleContentState extends State<_ConsoleContent> {
                 },
               ),
               _CollectionTab(
-                stream: _detectionsStream,
+                stream: db
+                    .collection('detectionItems')
+                    .where('userId', isEqualTo: userId)
+                    .snapshots(),
                 imageUrlKeys: const [],
                 summaryBuilder: (data) {
                   final result = data['result'] ?? '—';
@@ -134,7 +111,11 @@ class _ConsoleContentState extends State<_ConsoleContent> {
                 },
               ),
               _CollectionTab(
-                stream: _tasksStream,
+                stream: db
+                    .collection('tasks')
+                    .where('userId', isEqualTo: userId)
+                    .orderBy('createdAt', descending: true)
+                    .snapshots(),
                 imageUrlKeys: const [],
                 summaryBuilder: (data) {
                   final type = data['type'] ?? '?';
@@ -154,7 +135,7 @@ class _ConsoleContentState extends State<_ConsoleContent> {
                   }
                 },
               ),
-              _ProblemsTab(problems: widget.problems),
+              _ProblemsTab(problems: problems),
             ],
           ),
         ),
@@ -162,9 +143,12 @@ class _ConsoleContentState extends State<_ConsoleContent> {
     );
   }
 
-  Widget _badgeTab(Stream<QuerySnapshot> stream, String label) {
+  Widget _badgeTab(FirebaseFirestore db, String collection, String label) {
     return StreamBuilder<QuerySnapshot>(
-      stream: stream,
+      stream: db
+          .collection(collection)
+          .where('userId', isEqualTo: userId)
+          .snapshots(),
       builder: (context, snapshot) {
         final count = snapshot.data?.docs.length ?? 0;
         return Tab(

--- a/watermarking_webapp/pubspec.lock
+++ b/watermarking_webapp/pubspec.lock
@@ -50,7 +50,7 @@ packages:
     source: hosted
     version: "1.1.2"
   cloud_firestore:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: cloud_firestore
       sha256: "88abd6dc7786c23c8b5e434901bb0d79176414e52e9ab50a8e52552ff6148d7a"

--- a/watermarking_webapp/pubspec.yaml
+++ b/watermarking_webapp/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   # Firebase
   firebase_core: ^4.3.0
   firebase_auth: ^6.1.3
+  cloud_firestore: ^6.1.1
   firebase_database: ^12.1.1
   firebase_storage: ^13.0.5
 


### PR DESCRIPTION
## Summary
- Reverts `_ConsoleContent` from `StatefulWidget` back to `StatelessWidget` with separate Firestore queries for tab badges and tab bodies
- Fixes the Marked/Detections/Tasks tabs spinning forever (broadcast streams don't replay to late subscribers, and `TabBarView` lazily builds non-visible tabs)
- Includes `cloud_firestore` dependency and API build defines missed from PR #24

## Test plan
- [ ] Open Console, verify all 5 tabs load data (not just the first visible one)
- [ ] Switch between tabs, confirm each loads without infinite spinner

🤖 Generated with [Claude Code](https://claude.com/claude-code)